### PR TITLE
Add gen.person generators

### DIFF
--- a/index.js
+++ b/index.js
@@ -23,5 +23,6 @@ const gen = (spec) => {
 
 gen.address = require('./src/address')
 gen.random = require('./src/random')
+gen.person = require('./src/person')
 
 module.exports = gen

--- a/src/person.js
+++ b/src/person.js
@@ -1,0 +1,17 @@
+const faker = require('faker')
+
+const person = () => ({
+  username: person.username(),
+  firstname: person.firstname(),
+  lastname: person.lastname()
+})
+
+person.username = faker.internet.userName
+person.firstname = person.firstName = faker.name.firstName
+person.lastname = person.lastName = faker.name.lastName
+person.fullname = person.fullName = faker.name.findName
+person.title = faker.name.title
+person.namePrefix = faker.name.prefix
+person.nameSuffix = faker.name.suffix
+
+module.exports =  person

--- a/src/person.js
+++ b/src/person.js
@@ -6,7 +6,7 @@ const person = () => ({
   lastname: person.lastname()
 })
 
-person.username = faker.internet.userName
+person.username = person.userName = faker.internet.userName
 person.firstname = person.firstName = faker.name.firstName
 person.lastname = person.lastName = faker.name.lastName
 person.fullname = person.fullName = faker.name.findName
@@ -15,3 +15,4 @@ person.namePrefix = faker.name.prefix
 person.nameSuffix = faker.name.suffix
 
 module.exports =  person
+

--- a/test/person.js
+++ b/test/person.js
@@ -1,0 +1,70 @@
+import gen from '..'
+import {expect} from 'chai'
+
+describe('gen.person()', () => {
+  it('returns an object with the correct keys', () => {
+    const person = gen.person()
+
+    expect(person.username).to.be.a('string')
+    expect(person.firstname).to.be.a('string')
+    expect(person.lastname).to.be.a('string')
+  })
+})
+
+describe('gen.person.username()', () => {
+  it('returns a string greater than 3 characters', () => {
+    const username = gen.person.username()
+    expect(username).to.be.a('string')
+    expect(username).to.have.length.above(3)
+  })
+})
+
+describe('gen.person.firstname()', () => {
+  it('returns a non-empty string with alphabetical chars', () => {
+    const pattern = /^[a-zA-Z'-]+$/
+    const firstname = gen.person.firstname()
+    expect(firstname).to.match(pattern)
+  })
+})
+
+describe('gen.person.lastname()', () => {
+  it('returns a non-empty string with alphabetical chars', () => {
+    const pattern = /^[a-zA-Z'-]+$/
+    const lastname = gen.person.lastname()
+    expect(lastname).to.match(pattern)
+  })
+})
+
+describe('gen.person.fullname()', () => {
+  it('returns a non-empty string with only alphabetical chars', () => {
+    // Has a first and last name, don't match the ends in case of prefixes/suffixes
+    const pattern = /[a-zA-Z]+\s[a-zA-Z]+/
+    const fullname = gen.person.fullname()
+    expect(fullname).to.match(pattern)
+  })
+})
+
+describe('gen.person.title()', () => {
+  it('returns a non-empty string', () => {
+    const title = gen.person.title()
+    expect(title).to.be.a('string')
+    expect(title).to.not.be.empty
+  })
+})
+
+describe('gen.person.namePrefix()', () => {
+  it('returns a string not longer than 5 chars', () => {
+    const prefix = gen.person.namePrefix()
+    expect(prefix).to.be.a('string')
+    expect(prefix).to.have.length.below(5)
+  })
+})
+
+describe('gen.person.nameSuffix()', () => {
+  it('returns a string not longer than 5 chars', () => {
+    const suffix = gen.person.nameSuffix()
+    expect(suffix).to.be.a('string')
+    expect(suffix).to.have.length.below(5)
+  })
+})
+


### PR DESCRIPTION
Fixes #3 

The interface supports both `firstname` and `firstName` and their counterparts. I decided to support both because I don't like the look of `userName` and I don't want to think about which version I should be using. They should both just work.
